### PR TITLE
Add pip to linux (apt) install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ winget install Git.Git
 ```
 **For Linux: (APT)**
 ```
-sudo apt-get update && sudo apt-get install -y python3.10 git
+sudo apt-get update && sudo apt-get install -y python3.10 git pip
 ```
 **For Mac: (HomeBrew)**
 ```


### PR DESCRIPTION
Cause some debian based distros (ubuntu aarch minimal in my case) didn't had/installed pip with python